### PR TITLE
fix submit buttons on welfare and school app

### DIFF
--- a/authentication/forms/users.py
+++ b/authentication/forms/users.py
@@ -51,4 +51,5 @@ class TeacherForm(forms.ModelForm):
                 Column("qualifications", css_class="form-group col-md-4 mb-0"),
                 css_class="form-row",
             ),
+            Submit('submit', 'Submit')
         )

--- a/historical_surveillance/forms.py
+++ b/historical_surveillance/forms.py
@@ -14,6 +14,9 @@ class DistrictForms(forms.ModelForm):
             "created_by": TextInput(attrs={"readonly": "readonly"}),
             "updated_by": TextInput(attrs={"readonly": "readonly"}),
         }
+    helper = FormHelper()
+    helper.add_input(Submit('submit', 'Submit', css_class='btn-primary'))
+    helper.form_method = 'POST'
 
 
 class AggregateEnrollmentForms(forms.ModelForm):
@@ -32,6 +35,9 @@ class AggregateEnrollmentForms(forms.ModelForm):
                                            attrs={'class': 'form-control'})
         }
         """
+    helper = FormHelper()
+    helper.add_input(Submit('submit', 'Submit', css_class='btn-primary'))
+    helper.form_method = 'POST'
 
 
 class SchoolForms(forms.ModelForm):
@@ -42,6 +48,9 @@ class SchoolForms(forms.ModelForm):
             "created_by": TextInput(attrs={"readonly": "readonly"}),
             "updated_by": TextInput(attrs={"readonly": "readonly"}),
         }
+    helper = FormHelper()
+    helper.add_input(Submit('submit', 'Submit', css_class='btn-primary'))
+    helper.form_method = 'POST'
 
 
 class EnrollmentForms(forms.ModelForm):
@@ -52,12 +61,18 @@ class EnrollmentForms(forms.ModelForm):
             "created_by": TextInput(attrs={"readonly": "readonly"}),
             "updated_by": TextInput(attrs={"readonly": "readonly"}),
         }
+    helper = FormHelper()
+    helper.add_input(Submit('submit', 'Submit', css_class='btn-primary'))
+    helper.form_method = 'POST'
 
 
 class NationalGenderEnrollmentForms(forms.ModelForm):
     class Meta:
         model = NationalGenderEnrollment
         fields = "__all__"
+    helper = FormHelper()
+    helper.add_input(Submit('submit', 'Submit', css_class='btn-primary'))
+    helper.form_method = 'POST'
 
 
 class NationalEducationCensusForms(forms.ModelForm):

--- a/historical_surveillance/templates/historical_form.html
+++ b/historical_surveillance/templates/historical_form.html
@@ -14,12 +14,13 @@
         {% endif %}
     </div>
     <div class="row">
-        <form method="post">
-            <h1>{{header}}</h1>
-            {% csrf_token %}
-            {{ form|crispy }}
-            <button type="submit" class="btn btn-primary">Submit</button>
-        </form>
+        <div class="col-12">
+            <form method="post">
+                <h1>{{header}}</h1>
+                {% csrf_token %}
+                {% crispy form %}
+            </form>
+        </div>
     </div>
 </div>
 {% endblock page_content %}

--- a/school/forms.py
+++ b/school/forms.py
@@ -18,6 +18,9 @@ class DistrictForm(forms.ModelForm):
     class Meta:
         model = District
         fields = ["district_name", "district_code"]
+    helper = FormHelper()
+    helper.add_input(Submit('submit', 'Submit', css_class='btn-primary'))
+    helper.form_method = 'POST'
 
 
 class SchoolForm(forms.ModelForm):
@@ -28,6 +31,9 @@ class SchoolForm(forms.ModelForm):
             "created_by": TextInput(attrs={"readonly": "readonly"}),
             "updated_by": TextInput(attrs={"readonly": "readonly"}),
         }
+    helper = FormHelper()
+    helper.add_input(Submit('submit', 'Submit', css_class='btn-primary'))
+    helper.form_method = 'POST'
 
 
 class StudentForm(forms.ModelForm):
@@ -136,6 +142,7 @@ class StudentForm(forms.ModelForm):
             "clubs_or_sports",
             "improvements_requested",
             "school_expectations",
+            Submit('submit', 'Submit')
         )
 
 
@@ -144,6 +151,9 @@ class CourseForm(forms.ModelForm):
     class Meta:
         model = Course
         fields = "__all__"
+    helper = FormHelper()
+    helper.add_input(Submit('submit', 'Submit', css_class='btn-primary'))
+    helper.form_method = 'POST'
 
 
 class CourseOutcomeForm(forms.ModelForm):
@@ -153,6 +163,9 @@ class CourseOutcomeForm(forms.ModelForm):
         widgets = {
             "notes": Textarea(attrs={"rows": 3, "cols": 20}),
         }
+    helper = FormHelper()
+    helper.add_input(Submit('submit', 'Submit', css_class='btn-primary'))
+    helper.form_method = 'POST'
 
 
 class PrincipalForm(forms.ModelForm):
@@ -186,6 +199,7 @@ class PrincipalForm(forms.ModelForm):
             "sex",
             "date_of_birth",
             "qualifications",
+            Submit('submit', 'Submit')
         )
 
 
@@ -516,6 +530,7 @@ class PrincipalAppraisalForm(forms.ModelForm):
             "principals_comments",
             "district_education_officer_comments",
             "chief_education_officer_comments",
+            Submit('submit', 'Submit')
         )
 
 
@@ -795,4 +810,5 @@ class TeacherAppraisalForm(forms.ModelForm):
             "teacher_comments",
             "district_officer_comments",
             "district_officer_recommendations",
+            Submit('submit', 'Submit')
         )

--- a/school/templates/form.html
+++ b/school/templates/form.html
@@ -14,12 +14,13 @@
         {% endif %}
     </div>
     <div class="row">
-        <form method="post">
-            <h1>{{header}}</h1>
-            {% csrf_token %}
-            {% crispy form %}
-            <button type="submit" class="btn btn-primary">Submit</button>
-        </form>
+        <div class="col-12">
+            <form method="post">
+                <h1>{{header}}</h1>
+                {% csrf_token %}
+                {% crispy form %}
+            </form>
+        </div>
     </div>
 </div>
 {% endblock page_content %}

--- a/welfare/forms.py
+++ b/welfare/forms.py
@@ -1,5 +1,6 @@
 from django import forms
-
+from crispy_forms.helper import FormHelper
+from crispy_forms.layout import Layout, Submit, Row, Column, HTML
 from .models import StudentSupportAssoc, SupportService
 from school.models import Student
 
@@ -12,6 +13,9 @@ class SupportServiceForm(forms.ModelForm):
             "created_by": forms.TextInput(attrs={"readonly": "readonly"}),
             "updated_by": forms.TextInput(attrs={"readonly": "readonly"}),
         }
+    helper = FormHelper()
+    helper.add_input(Submit('submit', 'Submit', css_class='btn-primary'))
+    helper.form_method = 'POST'
 
 
 class StudentSupportAssocForm(forms.ModelForm):
@@ -83,3 +87,6 @@ class StudentSupportAssocForm(forms.ModelForm):
             "end_date": forms.TextInput(attrs={"type": "date"}),
             "comment": forms.Textarea(attrs={"rows": 3, "cols": 20}),
         }
+    helper = FormHelper()
+    helper.add_input(Submit('submit', 'Submit', css_class='btn-primary'))
+    helper.form_method = 'POST'


### PR DESCRIPTION
When rendering form with `{% crispy form %}` the submit buttons needs to be added in the Form class definition (python code). Adding to the HTML doesn't work as the submit button gets rendered outside the `<form> ` tags and doesn't register as a proper submit button for the form.

Previously we were doing `{% form | crispy %}` so the submit button could be added in the HTML.

Found answer in the Crispy Forms Layout Helpers section in this link:

https://simpleisbetterthancomplex.com/tutorial/2018/11/28/advanced-form-rendering-with-django-crispy-forms.html